### PR TITLE
Added NFS monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Circadian uses a suite of 'idle heuristics' to determine when a system is idle. 
  * User activity in terminals (typing in PTY/SSH session)
  * Open SSH connections
  * Open SMB/Samba connections
+ * Open NFS connections
  * Active audio playback
  * CPU usage below specified threshold
  * Blacklisted processes

--- a/resources/circadian.conf.in
+++ b/resources/circadian.conf.in
@@ -47,6 +47,15 @@ ssh_block = yes
 # Default: no
 smb_block = no
 
+# Whether active NFS connections block the system from being idle.  Both
+# inbound and outbound connections will prevent the system from going idle
+# if this is 'yes'.
+#
+# Monitors netstat
+#
+# Default: no
+nfs_block = no
+
 # Whether active audio playback blocks the system from being idle.
 #
 # Monitors /proc/asound


### PR DESCRIPTION
Pretty straightforward.  NFS is handled mostly in the kernel at this point, so there's no 'nfsd' process to see in netstat, so we look for connections to port 2049.  Otherwise basically duplicating the code for SMB.  It does work like the SSH blocking in that it will block on both incoming (we are the NFS server) and outgoing (we are the NFS client) connections, which may not be ideal for some users.

