### PR TITLE
Pulseaudio support - Migrate to pactl instead of pacmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Circadian exists because modern Linux distros already support suspend-on-idle, b
 $ sudo dpkg -i circadian_0.6.0-1_amd64.deb
 ```
 
-If desired, install tooling to detect network (`netstat`), X11 (`xssstate` and`xprintidle`), audio activity (`pacmd`):
+If desired, install tooling to detect network (`netstat`), X11 (`xssstate` and`xprintidle`), audio activity (`pactl`):
 
 ```
 $ sudo apt-get install suckless-tools xprintidle net-tools pulseaudio-utils
@@ -98,7 +98,7 @@ Follow systemd instructions, and port circadian.service to whatever format you w
     * xssstate
     * xprintidle
     * netstat
-    * pacmd
+    * pactl
     * rustc + cargo (if building locally)
 * Should already have
     * grep


### PR DESCRIPTION
Migrating from 'pacmd' to 'pactl' to determine pulseaudio (and its drop in replacement 'pipewire') audio status.

Pactl is also supported by PipeWire drop in pulseaudio replacement while 'pacmd' is not.

For more info see https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/357

Original Issue:
`speech-dispatcher-dummy` blocks audio all the time. See [this](https://github.com/brailcom/speechd/issues/787) and [this](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/daemon/pipewire-pulse.conf.in#L139]

After that i migrated to pipewire, since somehow this is not yet upstreamed to pulseaudio default config