### PR TITLE
Use locale `LC_ALL=C`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1109,6 +1109,9 @@ fn main() {
         VERBOSITY.store(verbosity, Ordering::SeqCst);
     }
 
+    // override user locale to make all command outputs uniform (e.g. when parsing column headers or dates/times)
+    std::env::set_var("LC_ALL", "C");
+
     if launch_opts.test {
         println!("Got --test: running idle test and exiting.");
         let start = time::now_utc().to_timespec().sec as i64;


### PR DESCRIPTION
I noticed when a non-default locale is used the `FROM` header name in `w` changes to the local language. Also the time format is different, which trips the `w` time parsing (there is an additional space before `m`).

As for root the locale is usually not changed this is likely not a problem. Still, I would provide `C` as the default to avoid unexpected changes in command outputs.

```bash
$ circadian --test |grep -e ^x -e ^w
w*              : 242
xssstate*       : w command arguments invalid
xprintidle*     : w command arguments invalid

$ LC_ALL=C circadian --test |grep -e ^x -e ^w
w*              : 14520
xssstate*       : 4294967
xprintidle*     : 4294967

$ w -usf
 14:16:04 up  4:14,  1 user,  load average: 1,07, 1,20, 0,95
USER     TTY      VON               IDLE WHAT
bbx0      tty2     tty2              4:14 m /usr/lib/gdm-wayland-session /usr/bin/gnome-session

$ LC_ALL=C w -usf
 14:16:11 up  4:14,  1 user,  load average: 0.98, 1.17, 0.94
USER     TTY      FROM              IDLE WHAT
bbx0      tty2     tty2              4:14m /usr/lib/gdm-wayland-session /usr/bin/gnome-session
```

