### PR TITLE
Added fix for running idle trigger after system wake due to race condition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1173,7 +1173,7 @@ fn main() {
         // trigger.
         // Otherwise if it's idle, the idle command hasn't already run, and it has been
         // at least |idle_time| since the service started: enter idle state.
-        if watchdog + 30 < now && idle.is_idle && !idle_triggered {
+        if watchdog + 30 > now && idle.is_idle && !idle_triggered {
             let tests = test_nonidle(&config);
             if !tests.is_blocked {
                 println!("Idle state active:\n{}{}", idle, tests);


### PR DESCRIPTION
I had some issues with suspending right after wake up. As far as i could see, it might be possible to hit the idle trigger before we do the wake up detection farther down (race condition due to thread suspension etc.). That is why i introduced this additional check here.

```
Mär 11 14:54:14 white circadian[818]: System suspending.
Mär 11 14:54:14 white circadian[818]: Idle command succeeded.
Mär 11 14:54:45 white circadian[818]: Idle state active:
Mär 11 14:54:45 white circadian[818]: w               : 1073
Mär 11 14:54:45 white circadian[818]: xssstate*       : 4294967
Mär 11 14:54:45 white circadian[818]: xprintidle*     : 4294967
Mär 11 14:54:45 white circadian[818]: Wake block      : 0
Mär 11 14:54:45 white circadian[818]: TTY (combined)  : 1073
Mär 11 14:54:45 white circadian[818]: X11 (combined)* : 4294967
Mär 11 14:54:45 white circadian[818]: Idle (min)      : 4294967
Mär 11 14:54:45 white circadian[818]: Idle target     : 900
Mär 11 14:54:45 white circadian[818]: Until idle      : 0
Mär 11 14:54:45 white circadian[818]: IDLE?           : true
Mär 11 14:54:45 white circadian[818]: CPU load*       : false
Mär 11 14:54:45 white circadian[818]: SSH*            : false
Mär 11 14:54:45 white circadian[818]: SMB             : false
Mär 11 14:54:45 white circadian[818]: NFS             : false
Mär 11 14:54:45 white circadian[818]: Audio*          : false
Mär 11 14:54:45 white circadian[818]: Processes*      : false
Mär 11 14:54:45 white circadian[818]: BLOCKED?        : false
Mär 11 14:54:45 white circadian[818]: System suspending.
Mär 11 14:54:45 white circadian[818]: Idle command succeeded.
Mär 11 14:55:12 white circadian[818]: Idle state active:
Mär 11 14:55:12 white circadian[818]: w               : 1100
Mär 11 14:55:12 white circadian[818]: xssstate*       : 4294967
Mär 11 14:55:12 white circadian[818]: xprintidle*     : 4294967
Mär 11 14:55:12 white circadian[818]: Wake block      : 0
Mär 11 14:55:12 white circadian[818]: TTY (combined)  : 1100
Mär 11 14:55:12 white circadian[818]: X11 (combined)* : 4294967
Mär 11 14:55:12 white circadian[818]: Idle (min)      : 4294967
Mär 11 14:55:12 white circadian[818]: Idle target     : 900
Mär 11 14:55:12 white circadian[818]: Until idle      : 0
Mär 11 14:55:12 white circadian[818]: IDLE?           : true
Mär 11 14:55:12 white circadian[818]: CPU load*       : false
Mär 11 14:55:12 white circadian[818]: SSH*            : false
Mär 11 14:55:12 white circadian[818]: SMB             : false
Mär 11 14:55:12 white circadian[818]: NFS             : false
Mär 11 14:55:12 white circadian[818]: Audio*          : false
Mär 11 14:55:12 white circadian[818]: Processes*      : false
Mär 11 14:55:12 white circadian[818]: BLOCKED?        : false
Mär 11 14:55:12 white circadian[818]: System suspending.
Mär 11 14:55:12 white circadian[818]: Idle command succeeded.
Mär 11 14:55:44 white circadian[818]: Watchdog missed.  Wake from sleep!
```