### PR TITLE
Remove w and use native Rust to check tty idle times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -94,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -235,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,7 +301,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -297,18 +318,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -356,9 +377,23 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.157"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "static_assertions"
@@ -384,6 +419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,12 +440,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "libc",
+ "num-conv",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -407,16 +456,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Follow systemd instructions, and port circadian.service to whatever format you w
 * Should already have
     * grep
     * awk
-    * w
     * id
     * uptime
     * pgrep

--- a/resources/circadian.conf.in
+++ b/resources/circadian.conf.in
@@ -23,7 +23,9 @@ verbosity = 0
 #
 # At least one of tty_input or x11_input must be 'yes'.
 #
-# Monitors the idle column of the 'w' command.
+# Monitors the idle time for each TTY device by subtracting the last access 
+# time of the device from the current system time. The minimum idle time across all checked
+# TTY devices is used.
 #
 # Default: yes
 tty_input = yes

--- a/src/main.rs
+++ b/src/main.rs
@@ -1020,8 +1020,8 @@ fn main() {
         println!("tty_input or x11_input must be enabled.  Exiting.");
         std::process::exit(1);
     }
-    if config.tty_input && !command_exists("w") {
-        println!("'w' command required by tty_input failed.  Exiting.");
+    if config.tty_input && !command_exists("stat") {
+        println!("'stat' command required by tty_input failed.  Exiting.");
         std::process::exit(1);
     }
     if config.x11_input &&

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,38 +20,33 @@
  * You should have received a copy of the GNU General Public License
  * along with Circadian.  If not, see <http://www.gnu.org/licenses/>.
  */
-extern crate regex;
 
-use std::collections::HashSet;
-// use std::io::BufRead;
-use std::os::linux::fs::MetadataExt;
-// use regex::Regex;
-
-extern crate glob;
-use glob::glob;
-
+ // External crates
 extern crate clap;
-use clap::Parser;
-
+extern crate glob;
 extern crate ini;
-use ini::Ini;
-
 extern crate nix;
-use nix::sys::signal;
-
+extern crate regex;
 extern crate time;
-use time::macros::*;
-
 extern crate users;
-use users::get_user_by_name;
 
+// Standard library imports
+use std::collections::HashSet;
+use std::fmt::Debug;
 use std::io::Write;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::process::Stdio;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use std::os::unix::process::CommandExt;
+// Crate-specific imports
+use clap::Parser;
+use glob::glob;
+use ini::Ini;
+use nix::sys::signal;
+use time::macros::*;
+use users::get_user_by_name;
 
 pub static VERBOSITY: AtomicUsize = AtomicUsize::new(0);
 pub const MAX_VERBOSITY: usize = 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,41 +343,6 @@ fn parse_w_time(time_str: &str) -> Result<u32, CircadianError> {
 }
 
 
-// Returns tuple containing argument string to provide to `w` to have
-// the FROM field included, and the 0-indexed offset of the field.
-fn w_from_args() -> Result<(String, usize), CircadianError> {
-    // Ask for a fake user to get just the header and check if the
-    // FROM field is enabled.
-    let w_output = Command::new("w")
-        .arg("-us")
-        .arg("CIRCADIAN_FAKEUSER")
-        .output()?;
-    let w_fields: Vec<String> = w_output.stdout
-        .lines()
-        .nth(1) // second line is the header
-        .ok_or(CircadianError("w command has no output".into()))??
-        .split_whitespace().map(|x| x.to_owned()).collect();
-    let from_header = String::from("FROM");
-    let (hargs, args) = match w_fields.contains(&from_header) {
-        true => ("-hus".to_string(), "-us".to_string()),
-        false => ("-husf".to_string(), "-usf".to_string()),
-    };
-
-    // Do it again with FROM field on and find its index.
-    let w_output = Command::new("w")
-        .arg(&args)
-        .arg("CIRCADIAN_FAKEUSER")
-        .output()?;
-    let w_fields: Vec<String> = w_output.stdout
-        .lines()
-        .nth(1)
-        .ok_or(CircadianError("w command has no output".into()))??
-        .split_whitespace().map(|x| x.to_owned()).collect();
-    let idx = w_fields.iter()
-        .position(|x| x == &from_header)
-        .ok_or(CircadianError("w command arguments invalid".into()))?;
-    Ok((hargs, idx))
-}
 
 fn xauthority_from_cmdline(display: &str) -> Result<String, CircadianError> {
     // Look for PIDs of processes with a variety of X11-related names.

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,41 +342,6 @@ fn parse_w_time(time_str: &str) -> Result<u32, CircadianError> {
     Ok((hours*60*60) + (mins*60) + secs)
 }
 
-// count number of fields in 'w' output
-//
-// This is a stupid requirement because some linux distros build w
-// with the 'FROM' field enabled by default and others with it
-// disabled.  'w' has a command-line option to *toggle* the field, but
-// no to forcibly enable/disable it.
-fn count_w_fields() -> Result<usize, CircadianError> {
-    let w_stdout = Stdio::piped();
-    let s_stdout = Stdio::piped();
-    let mut w_output = Command::new("w")
-        .arg("-us")
-        .stdout(w_stdout).spawn()?;
-    let _ = w_output.wait()?;
-    let w_stdout = w_output.stdout
-        .ok_or(CircadianError("w command has no output".into()))?;
-    // print just the second row, the header
-    let mut sed_output = Command::new("sed")
-        .arg("-n")
-        .arg("2p")
-        .stdin(w_stdout)
-        .stdout(s_stdout)
-        .spawn()?;
-    let _ = sed_output.wait()?;
-    let s_stdout = sed_output.stdout
-        .ok_or(CircadianError("w/sed command has no output".into()))?;
-    let awk_output = Command::new("awk")
-        .arg("{print NF}")
-        .stdin(s_stdout)
-        .output()?;
-    let num_fields: usize = String::from_utf8(awk_output.stdout)
-        .unwrap_or(String::new())
-        .trim()
-        .parse::<usize>()?;
-    Ok(num_fields)
-}
 
 // Returns tuple containing argument string to provide to `w` to have
 // the FROM field included, and the 0-indexed offset of the field.

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,7 +507,7 @@ fn idle_display(cmd: &str, args: Vec<&str>) -> IdleResult {
                         }
                     },
                     Err(e) => {
-                        eprintln!("WARNING: {} failed for socket {} with error: {}", cmd, device, e);
+                        eprintln!("ERROR: {} failed for socket {} with error: {}", cmd, device, e);
                     },
                 }
         }
@@ -803,8 +803,6 @@ fn test_idle(config: &CircadianConfig, start: i64) -> IdleResponse {
     let idle_remain: u64 =
             std::cmp::max(config.idle_time as i64 - min_idle as i64, 0) as u64;
     IdleResponse {
-        // w_idle: tty,
-        // w_enabled: config.tty_input,
         xssstate_idle: xssstate,
         xssstate_enabled: config.x11_input,
         xprintidle_idle: xprintidle,
@@ -1003,10 +1001,6 @@ fn main() {
 
     if !config.tty_input && !config.x11_input {
         println!("tty_input or x11_input must be enabled.  Exiting.");
-        std::process::exit(1);
-    }
-    if config.tty_input && !command_exists("stat") {
-        println!("'stat' command required by tty_input failed.  Exiting.");
         std::process::exit(1);
     }
     if config.x11_input &&

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,11 @@ impl From<nix::Error> for CircadianError {
         CircadianError(error.to_string().to_owned())
     }
 }
+impl From<std::time::SystemTimeError> for CircadianError {
+    fn from(error: std::time::SystemTimeError) -> Self {
+        CircadianError(error.to_string().to_owned())
+    }
+}
 impl From<time::error::Parse> for CircadianError {
     fn from(error: time::error::Parse) -> Self {
         CircadianError(error.to_string().to_owned())

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,41 +306,6 @@ fn command_exists(cmd: &str) -> bool {
         }
 }
 
-/// Parse idle time strings from 'w' command into seconds
-fn parse_w_time(time_str: &str) -> Result<u32, CircadianError> {
-    let mut secs: u32 = 0;
-    let mut mins: u32 = 0;
-    let mut hours:u32 = 0;
-    let re_sec = Regex::new(r"^\d+.\d+s$")?;
-    let re_min = Regex::new(r"^\d+:\d+$")?;
-    let re_hour = Regex::new(r"^\d+:\d+m$")?;
-    if re_sec.is_match(time_str) {
-        let time_str: &str = time_str.trim_matches('s');
-        let parts: Vec<u32> = time_str.split(".")
-            .map(|s| str::parse::<u32>(s).unwrap_or(0))
-            .collect();
-        secs = *parts.get(0).unwrap_or(&0);
-    }
-    else if re_min.is_match(time_str) {
-        let parts: Vec<u32> = time_str.split(":")
-            .map(|s| str::parse::<u32>(s).unwrap_or(0))
-            .collect();
-        mins = *parts.get(0).unwrap_or(&0);
-        secs = *parts.get(1).unwrap_or(&0);
-    }
-    else if re_hour.is_match(time_str) {
-        let time_str: &str = time_str.trim_matches('m');
-        let parts: Vec<u32> = time_str.split(":")
-            .map(|s| str::parse::<u32>(s).unwrap_or(0))
-            .collect();
-        hours = *parts.get(0).unwrap_or(&0);
-        mins = *parts.get(1).unwrap_or(&0);
-    }
-    else {
-        return Err(CircadianError("Invalid idle format".to_string()));
-    }
-    Ok((hours*60*60) + (mins*60) + secs)
-}
 
 
 


### PR DESCRIPTION
- Monitors the idle time for each TTY device by subtracting the last access time of the device from the current system time. The minimum idle time across all checked TTY devices is used.
- organize imports
- update Readme and sample conf file (old conf file will still work, but the comments have been updated)